### PR TITLE
feat: add auth context

### DIFF
--- a/Ampara/App.tsx
+++ b/Ampara/App.tsx
@@ -1,9 +1,16 @@
-import React, { useState } from "react";
+import React, {
+  useState,
+  createContext,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+} from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createStackNavigator } from "@react-navigation/stack";
 import { Ionicons } from "@expo/vector-icons";
 import { View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import "./global.css";
 
 import Dashboard from "./screens/dashboard/Dashboard";
@@ -12,6 +19,16 @@ import Health from "./screens/health/Health";
 import Settings from "./screens/settings/Settings";
 import CalendarScreen from "./screens/calendar/Calendar";
 import { LogIn, SignUp, ForgotPassword } from "./screens/log_in";
+
+type AuthContextType = {
+  isAuthenticated: boolean;
+  setIsAuthenticated: Dispatch<SetStateAction<boolean>>;
+};
+
+export const AuthContext = createContext<AuthContextType>({
+  isAuthenticated: false,
+  setIsAuthenticated: () => {},
+});
 
 const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -72,11 +89,28 @@ const MainTabs = () => (
 export default function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
+  useEffect(() => {
+    const restoreToken = async () => {
+      try {
+        const token = await AsyncStorage.getItem("authToken");
+        if (token) {
+          setIsAuthenticated(true);
+        }
+      } catch (error) {
+        // ignore restoring errors
+      }
+    };
+
+    restoreToken();
+  }, []);
+
   return (
     <View className="flex-1">
-      <NavigationContainer>
-        {isAuthenticated ? <MainTabs /> : <AuthStack />}
-      </NavigationContainer>
+      <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>
+        <NavigationContainer>
+          {isAuthenticated ? <MainTabs /> : <AuthStack />}
+        </NavigationContainer>
+      </AuthContext.Provider>
     </View>
   );
 }

--- a/Ampara/screens/log_in/LogIn.tsx
+++ b/Ampara/screens/log_in/LogIn.tsx
@@ -1,12 +1,25 @@
 import { View, Text, TouchableOpacity, TextInput, Image } from "react-native";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { AuthContext } from "../../App";
 
 const LogIn = () => {
   const navigation = useNavigation();
   const [showPassword, setShowPassword] = useState(false);
+  const { setIsAuthenticated } = useContext(AuthContext);
+
+  const handleLogin = async () => {
+    try {
+      // TODO: Replace with real authentication and token retrieval
+      await AsyncStorage.setItem("authToken", "dummy-token");
+      setIsAuthenticated(true);
+    } catch (error) {
+      // handle login error
+    }
+  };
 
   return (
     <SafeAreaView className="flex-1 bg-white">
@@ -48,7 +61,10 @@ const LogIn = () => {
               </TouchableOpacity>
             </View>
           </View>
-          <TouchableOpacity className="bg-blue-500 rounded-lg py-3">
+          <TouchableOpacity
+            onPress={handleLogin}
+            className="bg-blue-500 rounded-lg py-3"
+          >
             <Text className="text-white text-center font-bold">Log In</Text>
           </TouchableOpacity>
           <TouchableOpacity


### PR DESCRIPTION
## Summary
- add auth context and provider
- hook login screen into auth context and store token

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68993bd54f1c83228deaaac8d4ccfaea