### PR TITLE
Verify MongoDB connectivity in health endpoint

### DIFF
--- a/classProject/server/src/app.controller.ts
+++ b/classProject/server/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { connection } from 'mongoose';
 
 @Controller()
 export class AppController {
@@ -16,11 +17,31 @@ export class AppController {
   }
 
   @Get('health/db')
-  async getDatabaseHealth(): Promise<{ status: string; timestamp: string }> {
-    // TODO: Add actual database connection check
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-    };
+  async getDatabaseHealth(): Promise<{
+    status: string;
+    timestamp: string;
+    message?: string;
+  }> {
+    if (connection.readyState !== 1) {
+      return {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        message: 'Database connection is not ready',
+      };
+    }
+
+    try {
+      await connection.db.admin().ping();
+      return {
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        message: 'Database ping failed',
+      };
+    }
   }
 }


### PR DESCRIPTION
## Summary
- check Mongoose connection state and ping MongoDB in `/health/db`
- report `error` status with a message when the database is unreachable

## Testing
- `npm test` (fails: Test Suites: 3 failed, 1 passed)
- `npm run lint` (fails: multiple @typescript-eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_68995116e958832280f27dcf4e8e625c