### PR TITLE
Add auth guards and role protection to controllers

### DIFF
--- a/classProject/server/src/modules/advice-requests/advice-requests.controller.ts
+++ b/classProject/server/src/modules/advice-requests/advice-requests.controller.ts
@@ -6,31 +6,41 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { AdviceRequestsService } from './advice-requests.service';
 import { CreateAdviceRequestDto } from './dto/create-advice-request.dto';
 import { UpdateAdviceRequestDto } from './dto/update-advice-request.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../users/users.schema';
 
 @Controller('advice-requests')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class AdviceRequestsController {
   constructor(private readonly adviceRequestsService: AdviceRequestsService) {}
 
   @Post()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   create(@Body() createAdviceRequestDto: CreateAdviceRequestDto) {
     return this.adviceRequestsService.create(createAdviceRequestDto);
   }
 
   @Get()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findAll() {
     return this.adviceRequestsService.findAll();
   }
 
   @Get(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findOne(@Param('id') id: string) {
     return this.adviceRequestsService.findOne(id);
   }
 
   @Patch(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   update(
     @Param('id') id: string,
     @Body() updateAdviceRequestDto: UpdateAdviceRequestDto,
@@ -39,6 +49,7 @@ export class AdviceRequestsController {
   }
 
   @Delete(':id')
+  @Roles(UserRole.NURSE)
   remove(@Param('id') id: string) {
     return this.adviceRequestsService.remove(id);
   }

--- a/classProject/server/src/modules/ai-instructions/ai-instructions.controller.ts
+++ b/classProject/server/src/modules/ai-instructions/ai-instructions.controller.ts
@@ -6,36 +6,47 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { AiInstructionsService } from './ai-instructions.service';
 import { CreateAiInstructionDto } from './dto/create-ai-instruction.dto';
 import { UpdateAiInstructionDto } from './dto/update-ai-instruction.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../users/users.schema';
 
 @Controller('ai-instructions')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class AiInstructionsController {
   constructor(private readonly aiInstructionsService: AiInstructionsService) {}
 
   @Post()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   create(@Body() createAiInstructionDto: CreateAiInstructionDto) {
     return this.aiInstructionsService.create(createAiInstructionDto);
   }
 
   @Get()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findAll() {
     return this.aiInstructionsService.findAll();
   }
 
   @Get(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findOne(@Param('id') id: string) {
     return this.aiInstructionsService.findOne(id);
   }
 
   @Get('elder/:elderId')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findByElderId(@Param('elderId') elderId: string) {
     return this.aiInstructionsService.findByElderId(elderId);
   }
 
   @Patch(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   update(
     @Param('id') id: string,
     @Body() updateAiInstructionDto: UpdateAiInstructionDto,
@@ -44,6 +55,7 @@ export class AiInstructionsController {
   }
 
   @Delete(':id')
+  @Roles(UserRole.NURSE)
   remove(@Param('id') id: string) {
     return this.aiInstructionsService.remove(id);
   }

--- a/classProject/server/src/modules/calls/calls.controller.ts
+++ b/classProject/server/src/modules/calls/calls.controller.ts
@@ -6,41 +6,53 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { CallsService } from './calls.service';
 import { CreateCallDto } from './dto/create-call.dto';
 import { UpdateCallDto } from './dto/update-call.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../users/users.schema';
 
 @Controller('calls')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class CallsController {
   constructor(private readonly callsService: CallsService) {}
 
   @Post()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   create(@Body() createCallDto: CreateCallDto) {
     return this.callsService.create(createCallDto);
   }
 
   @Get()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findAll() {
     return this.callsService.findAll();
   }
 
   @Get(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findOne(@Param('id') id: string) {
     return this.callsService.findOne(id);
   }
 
   @Get('elder/:elderId')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findByElderId(@Param('elderId') elderId: string) {
     return this.callsService.findByElderId(elderId);
   }
 
   @Patch(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   update(@Param('id') id: string, @Body() updateCallDto: UpdateCallDto) {
     return this.callsService.update(id, updateCallDto);
   }
 
   @Delete(':id')
+  @Roles(UserRole.NURSE)
   remove(@Param('id') id: string) {
     return this.callsService.remove(id);
   }

--- a/classProject/server/src/modules/moods/moods.controller.ts
+++ b/classProject/server/src/modules/moods/moods.controller.ts
@@ -6,41 +6,53 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { MoodsService } from './moods.service';
 import { CreateMoodDto } from './dto/create-mood.dto';
 import { UpdateMoodDto } from './dto/update-mood.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../users/users.schema';
 
 @Controller('moods')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class MoodsController {
   constructor(private readonly moodsService: MoodsService) {}
 
   @Post()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   create(@Body() createMoodDto: CreateMoodDto) {
     return this.moodsService.create(createMoodDto);
   }
 
   @Get()
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findAll() {
     return this.moodsService.findAll();
   }
 
   @Get(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findOne(@Param('id') id: string) {
     return this.moodsService.findOne(id);
   }
 
   @Get('elder/:elderId')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   findByElderId(@Param('elderId') elderId: string) {
     return this.moodsService.findByElderId(elderId);
   }
 
   @Patch(':id')
+  @Roles(UserRole.FAMILY_MEMBER, UserRole.NURSE)
   update(@Param('id') id: string, @Body() updateMoodDto: UpdateMoodDto) {
     return this.moodsService.update(id, updateMoodDto);
   }
 
   @Delete(':id')
+  @Roles(UserRole.NURSE)
   remove(@Param('id') id: string) {
     return this.moodsService.remove(id);
   }


### PR DESCRIPTION
## Summary
- secure advice requests endpoints with JWT and role-based guards
- lock down calls controller with authentication and role checks
- require roles for ai instructions and moods routes

## Testing
- `npm test` *(fails: Property 'getHello' does not exist on type 'AppController'; Cannot read properties of null (reading 'email'); Nest can't resolve dependencies of the UsersService (?).)*

------
https://chatgpt.com/codex/tasks/task_e_689951180ae48322a6a5a2f59743d544