### PR TITLE
Handle missing entities with NotFoundException

### DIFF
--- a/classProject/server/src/modules/advice-requests/advice-requests.service.ts
+++ b/classProject/server/src/modules/advice-requests/advice-requests.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { AdviceRequest, AdviceRequestDocument } from './advice-request.schema';
@@ -25,8 +25,12 @@ export class AdviceRequestsService {
     return this.adviceRequestModel.find().exec();
   }
 
-  async findOne(id: string): Promise<AdviceRequest | null> {
-    return this.adviceRequestModel.findById(id).exec();
+  async findOne(id: string): Promise<AdviceRequest> {
+    const adviceRequest = await this.adviceRequestModel.findById(id).exec();
+    if (!adviceRequest) {
+      throw new NotFoundException(`AdviceRequest with id ${id} not found`);
+    }
+    return adviceRequest;
   }
 
   async findByElderId(elderId: string): Promise<AdviceRequest[]> {
@@ -46,13 +50,23 @@ export class AdviceRequestsService {
   async update(
     id: string,
     updateAdviceRequestDto: UpdateAdviceRequestDto,
-  ): Promise<AdviceRequest | null> {
-    return this.adviceRequestModel
+  ): Promise<AdviceRequest> {
+    const updatedAdviceRequest = await this.adviceRequestModel
       .findByIdAndUpdate(id, updateAdviceRequestDto, { new: true })
       .exec();
+    if (!updatedAdviceRequest) {
+      throw new NotFoundException(`AdviceRequest with id ${id} not found`);
+    }
+    return updatedAdviceRequest;
   }
 
-  async remove(id: string): Promise<AdviceRequest | null> {
-    return this.adviceRequestModel.findByIdAndDelete(id).exec();
+  async remove(id: string): Promise<AdviceRequest> {
+    const deletedAdviceRequest = await this.adviceRequestModel
+      .findByIdAndDelete(id)
+      .exec();
+    if (!deletedAdviceRequest) {
+      throw new NotFoundException(`AdviceRequest with id ${id} not found`);
+    }
+    return deletedAdviceRequest;
   }
 }

--- a/classProject/server/src/modules/ai-instructions/ai-instructions.service.ts
+++ b/classProject/server/src/modules/ai-instructions/ai-instructions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { AiInstruction, AiInstructionDocument } from './ai-instruction.schema';
@@ -23,8 +23,12 @@ export class AiInstructionsService {
     return this.aiInstructionModel.find().exec();
   }
 
-  async findOne(id: string): Promise<AiInstruction | null> {
-    return this.aiInstructionModel.findById(id).exec();
+  async findOne(id: string): Promise<AiInstruction> {
+    const instruction = await this.aiInstructionModel.findById(id).exec();
+    if (!instruction) {
+      throw new NotFoundException(`AiInstruction with id ${id} not found`);
+    }
+    return instruction;
   }
 
   async findByElderId(elderId: string): Promise<AiInstruction[]> {
@@ -37,13 +41,23 @@ export class AiInstructionsService {
   async update(
     id: string,
     updateAiInstructionDto: UpdateAiInstructionDto,
-  ): Promise<AiInstruction | null> {
-    return this.aiInstructionModel
+  ): Promise<AiInstruction> {
+    const updatedInstruction = await this.aiInstructionModel
       .findByIdAndUpdate(id, updateAiInstructionDto, { new: true })
       .exec();
+    if (!updatedInstruction) {
+      throw new NotFoundException(`AiInstruction with id ${id} not found`);
+    }
+    return updatedInstruction;
   }
 
-  async remove(id: string): Promise<AiInstruction | null> {
-    return this.aiInstructionModel.findByIdAndDelete(id).exec();
+  async remove(id: string): Promise<AiInstruction> {
+    const deletedInstruction = await this.aiInstructionModel
+      .findByIdAndDelete(id)
+      .exec();
+    if (!deletedInstruction) {
+      throw new NotFoundException(`AiInstruction with id ${id} not found`);
+    }
+    return deletedInstruction;
   }
 }

--- a/classProject/server/src/modules/calls/calls.service.ts
+++ b/classProject/server/src/modules/calls/calls.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Call, CallDocument } from './call.schema';
@@ -18,21 +18,33 @@ export class CallsService {
     return this.callModel.find().exec();
   }
 
-  async findOne(id: string): Promise<Call | null> {
-    return this.callModel.findById(id).exec();
+  async findOne(id: string): Promise<Call> {
+    const call = await this.callModel.findById(id).exec();
+    if (!call) {
+      throw new NotFoundException(`Call with id ${id} not found`);
+    }
+    return call;
   }
 
   async findByElderId(elderId: string): Promise<Call[]> {
     return this.callModel.find({ elderId }).sort({ calledAt: -1 }).exec();
   }
 
-  async update(id: string, updateCallDto: UpdateCallDto): Promise<Call | null> {
-    return this.callModel
+  async update(id: string, updateCallDto: UpdateCallDto): Promise<Call> {
+    const updatedCall = await this.callModel
       .findByIdAndUpdate(id, updateCallDto, { new: true })
       .exec();
+    if (!updatedCall) {
+      throw new NotFoundException(`Call with id ${id} not found`);
+    }
+    return updatedCall;
   }
 
-  async remove(id: string): Promise<Call | null> {
-    return this.callModel.findByIdAndDelete(id).exec();
+  async remove(id: string): Promise<Call> {
+    const deletedCall = await this.callModel.findByIdAndDelete(id).exec();
+    if (!deletedCall) {
+      throw new NotFoundException(`Call with id ${id} not found`);
+    }
+    return deletedCall;
   }
 }

--- a/classProject/server/src/modules/moods/moods.service.ts
+++ b/classProject/server/src/modules/moods/moods.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Mood, MoodDocument } from './mood.schema';
@@ -18,21 +18,33 @@ export class MoodsService {
     return this.moodModel.find().exec();
   }
 
-  async findOne(id: string): Promise<Mood | null> {
-    return this.moodModel.findById(id).exec();
+  async findOne(id: string): Promise<Mood> {
+    const mood = await this.moodModel.findById(id).exec();
+    if (!mood) {
+      throw new NotFoundException(`Mood with id ${id} not found`);
+    }
+    return mood;
   }
 
   async findByElderId(elderId: string): Promise<Mood[]> {
     return this.moodModel.find({ elderId }).sort({ timestamp: -1 }).exec();
   }
 
-  async update(id: string, updateMoodDto: UpdateMoodDto): Promise<Mood | null> {
-    return this.moodModel
+  async update(id: string, updateMoodDto: UpdateMoodDto): Promise<Mood> {
+    const updatedMood = await this.moodModel
       .findByIdAndUpdate(id, updateMoodDto, { new: true })
       .exec();
+    if (!updatedMood) {
+      throw new NotFoundException(`Mood with id ${id} not found`);
+    }
+    return updatedMood;
   }
 
-  async remove(id: string): Promise<Mood | null> {
-    return this.moodModel.findByIdAndDelete(id).exec();
+  async remove(id: string): Promise<Mood> {
+    const deletedMood = await this.moodModel.findByIdAndDelete(id).exec();
+    if (!deletedMood) {
+      throw new NotFoundException(`Mood with id ${id} not found`);
+    }
+    return deletedMood;
   }
 }


### PR DESCRIPTION
## Summary
- throw `NotFoundException` in advice request, AI instruction, call, and mood services when find/update/remove return null

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null)*
- `npm run lint` *(fails: 80 problems (77 errors, 3 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6899511a25848322b82c86c997f08795