### PR TITLE
Add auth context and login flow with API client

### DIFF
--- a/Ampara/screens/log_in/LogIn.tsx
+++ b/Ampara/screens/log_in/LogIn.tsx
@@ -1,12 +1,43 @@
 import { View, Text, TouchableOpacity, TextInput, Image } from "react-native";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { AuthContext } from "../../App";
+import apiFetch from "../../services/api";
 
 const LogIn = () => {
   const navigation = useNavigation();
+  const { setIsAuthenticated } = useContext(AuthContext);
   const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setError(null);
+    try {
+      const response = await apiFetch("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        setError(message || "Login failed");
+        return;
+      }
+
+      const { access_token, user } = await response.json();
+      await AsyncStorage.setItem("access_token", access_token);
+      await AsyncStorage.setItem("user", JSON.stringify(user));
+      setIsAuthenticated(true);
+    } catch (e) {
+      setError("Login failed");
+    }
+  };
 
   return (
     <SafeAreaView className="flex-1 bg-white">
@@ -18,16 +49,24 @@ const LogIn = () => {
               className="w-48 h-48"
             />
           </View>
+          {error && (
+            <Text className="text-red-500 text-center mb-4">{error}</Text>
+          )}
           <View className="mb-6">
             <TextInput
               placeholder="Email"
+              value={email}
+              onChangeText={setEmail}
               className="border-b border-gray-300 py-2 px-1"
+              autoCapitalize="none"
             />
           </View>
           <View className="mb-6">
             <View className="flex-row items-center border-b border-gray-300">
               <TextInput
                 placeholder="Password"
+                value={password}
+                onChangeText={setPassword}
                 secureTextEntry={!showPassword}
                 className="flex-1 py-2 px-1"
               />
@@ -48,7 +87,10 @@ const LogIn = () => {
               </TouchableOpacity>
             </View>
           </View>
-          <TouchableOpacity className="bg-blue-500 rounded-lg py-3">
+          <TouchableOpacity
+            className="bg-blue-500 rounded-lg py-3"
+            onPress={handleLogin}
+          >
             <Text className="text-white text-center font-bold">Log In</Text>
           </TouchableOpacity>
           <TouchableOpacity

--- a/Ampara/services/api.ts
+++ b/Ampara/services/api.ts
@@ -1,0 +1,16 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const BASE_URL = `http://${process.env.SERVER_URL || 'localhost:3000'}`;
+
+export const apiFetch = async (endpoint: string, options: RequestInit = {}) => {
+  const token = await AsyncStorage.getItem('access_token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(options.headers || {}),
+  } as Record<string, string>;
+
+  return fetch(`${BASE_URL}${endpoint}`, { ...options, headers });
+};
+
+export default apiFetch;


### PR DESCRIPTION
## Summary
- implement login screen state, API call, error handling and token storage
- introduce AuthContext with persistent login state
- add reusable API client for authenticated requests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689969b9c35883229a9159b8bebe2948