### PR TITLE
feat: implement sign up registration

### DIFF
--- a/Ampara/screens/log_in/SignUp.tsx
+++ b/Ampara/screens/log_in/SignUp.tsx
@@ -1,15 +1,31 @@
 
 import { View, Text, TouchableOpacity, TextInput, Image, Alert } from 'react-native'
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation } from '@react-navigation/native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import { AuthContext } from '../../App'
+import apiFetch from '../../services/api'
 
 const SignUp = () => {
     const navigation = useNavigation()
+    const { setIsAuthenticated } = useContext(AuthContext)
     const [showPassword, setShowPassword] = useState(false)
+    const [name, setName] = useState('')
+    const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    const [role, setRole] = useState('')
+    const [linkedElder, setLinkedElder] = useState('')
+    const [error, setError] = useState<string | null>(null)
 
-    const handleSignUp = () => {
+    const handleSignUp = async () => {
+        setError(null)
+        if (!name || !email || !password || !role) {
+            setError('All fields are required')
+            return
+        }
+
         const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/
         if (!passwordRegex.test(password)) {
             Alert.alert(
@@ -18,7 +34,32 @@ const SignUp = () => {
             )
             return
         }
-        // Handle sign up logic here
+
+        try {
+            const response = await apiFetch('/auth/register', {
+                method: 'POST',
+                body: JSON.stringify({
+                    name,
+                    email,
+                    password,
+                    role,
+                    ...(linkedElder ? { linkedElders: [linkedElder] } : {}),
+                }),
+            })
+
+            if (!response.ok) {
+                const message = await response.text()
+                setError(message || 'Registration failed')
+                return
+            }
+
+            const { access_token, user } = await response.json()
+            await AsyncStorage.setItem('access_token', access_token)
+            await AsyncStorage.setItem('user', JSON.stringify(user))
+            setIsAuthenticated(true)
+        } catch (e) {
+            setError('Registration failed')
+        }
     }
 
     return (
@@ -26,15 +67,29 @@ const SignUp = () => {
             <View className="flex-1 bg-white p-6">
                 <View className="flex-1 justify-center">
                     <Text className="text-3xl font-bold text-center mb-10">Create Account</Text>
+                    {error && <Text className="text-red-500 text-center mb-4">{error}</Text>}
                     <View className="mb-6">
                         <TextInput
                             placeholder="Full Name"
+                            value={name}
+                            onChangeText={setName}
                             className="border-b border-gray-300 py-2 px-1"
                         />
                     </View>
                     <View className="mb-6">
                         <TextInput
                             placeholder="Email"
+                            value={email}
+                            onChangeText={setEmail}
+                            autoCapitalize="none"
+                            className="border-b border-gray-300 py-2 px-1"
+                        />
+                    </View>
+                    <View className="mb-6">
+                        <TextInput
+                            placeholder="Role (e.g., FAMILY_MEMBER)"
+                            value={role}
+                            onChangeText={setRole}
                             className="border-b border-gray-300 py-2 px-1"
                         />
                     </View>
@@ -58,6 +113,8 @@ const SignUp = () => {
                     <View className="mb-6">
                         <TextInput
                             placeholder="Connect to Elder (Name or ID)"
+                            value={linkedElder}
+                            onChangeText={setLinkedElder}
                             className="border-b border-gray-300 py-2 px-1"
                         />
                     </View>


### PR DESCRIPTION
## Summary
- add state for name, email, password, role, and linked elder
- implement POST /auth/register and persist token and user
- show validation errors during sign up

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68996a5abf4c8322a86c40d5a331e46b