### PR TITLE
Add registration API and Ionicons toggle to signup

### DIFF
--- a/Ampara/screens/log_in/SignUp.tsx
+++ b/Ampara/screens/log_in/SignUp.tsx
@@ -1,15 +1,25 @@
 
-import { View, Text, TouchableOpacity, TextInput, Image, Alert } from 'react-native'
-import React, { useState } from 'react'
+import { View, Text, TouchableOpacity, TextInput, Alert } from 'react-native'
+import React, { useState, useContext } from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation } from '@react-navigation/native'
+import Ionicons from '@expo/vector-icons/Ionicons'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import { AuthContext } from '../../App'
+import apiFetch from '../../services/api'
 
 const SignUp = () => {
     const navigation = useNavigation()
+    const { setIsAuthenticated } = useContext(AuthContext)
     const [showPassword, setShowPassword] = useState(false)
+    const [name, setName] = useState('')
+    const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    const [elder, setElder] = useState('')
+    const [error, setError] = useState<string | null>(null)
 
-    const handleSignUp = () => {
+    const handleSignUp = async () => {
         const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/
         if (!passwordRegex.test(password)) {
             Alert.alert(
@@ -18,7 +28,27 @@ const SignUp = () => {
             )
             return
         }
-        // Handle sign up logic here
+
+        setError(null)
+        try {
+            const response = await apiFetch('/auth/register', {
+                method: 'POST',
+                body: JSON.stringify({ name, email, password, elderConnection: elder })
+            })
+
+            if (!response.ok) {
+                const message = await response.text()
+                setError(message || 'Registration failed')
+                return
+            }
+
+            const { access_token, user } = await response.json()
+            await AsyncStorage.setItem('access_token', access_token)
+            await AsyncStorage.setItem('user', JSON.stringify(user))
+            setIsAuthenticated(true)
+        } catch (e) {
+            setError('Registration failed')
+        }
     }
 
     return (
@@ -26,16 +56,24 @@ const SignUp = () => {
             <View className="flex-1 bg-white p-6">
                 <View className="flex-1 justify-center">
                     <Text className="text-3xl font-bold text-center mb-10">Create Account</Text>
+                    {error && (
+                        <Text className="text-red-500 text-center mb-4">{error}</Text>
+                    )}
                     <View className="mb-6">
                         <TextInput
                             placeholder="Full Name"
+                            value={name}
+                            onChangeText={setName}
                             className="border-b border-gray-300 py-2 px-1"
                         />
                     </View>
                     <View className="mb-6">
                         <TextInput
                             placeholder="Email"
+                            value={email}
+                            onChangeText={setEmail}
                             className="border-b border-gray-300 py-2 px-1"
+                            autoCapitalize="none"
                         />
                     </View>
                     <View className="mb-6">
@@ -47,10 +85,19 @@ const SignUp = () => {
                                 onChangeText={setPassword}
                                 className="flex-1 py-2 px-1"
                             />
-                            <TouchableOpacity onPress={() => setShowPassword(!showPassword)}>
-                                <Image
-                                    source={!showPassword ? require('../../assets/adaptive-icon.png') : require('../../assets/icon.png')}
-                                    className="w-6 h-6"
+                            <TouchableOpacity
+                                onPress={() => setShowPassword((s) => !s)}
+                                accessibilityRole="button"
+                                accessibilityLabel={
+                                    showPassword ? 'Hide password' : 'Show password'
+                                }
+                                hitSlop={8}
+                                style={{ position: 'absolute', right: 8 }}
+                            >
+                                <Ionicons
+                                    name={showPassword ? 'eye-off-outline' : 'eye-outline'}
+                                    size={24}
+                                    color="black"
                                 />
                             </TouchableOpacity>
                         </View>
@@ -58,6 +105,8 @@ const SignUp = () => {
                     <View className="mb-6">
                         <TextInput
                             placeholder="Connect to Elder (Name or ID)"
+                            value={elder}
+                            onChangeText={setElder}
                             className="border-b border-gray-300 py-2 px-1"
                         />
                     </View>


### PR DESCRIPTION
## Summary
- replace image password toggle with Ionicons
- call `/auth/register` and persist JWT/user on success

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689c74e31a488322a2f65cde6b8e094f