### PR TITLE
Add AppHeader component for logo header

### DIFF
--- a/Ampara/App.tsx
+++ b/Ampara/App.tsx
@@ -14,6 +14,7 @@ import Settings from "./screens/settings/Settings";
 import CalendarScreen from "./screens/calendar/Calendar";
 import { LogIn, SignUp, ForgotPassword, WelcomeScreen } from "./screens/log_in";
 import { AuthContext } from "./controllers/AuthContext";
+import AppHeader from "./AppHeader";
 
 const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -31,6 +32,9 @@ const MainTabs = () => (
   <Tab.Navigator
     initialRouteName="Dashboard"
     screenOptions={({ route }) => ({
+      header: () => (
+        <AppHeader title={route.name === "Dashboard" ? "Ampara" : undefined} />
+      ),
       tabBarIcon: ({ focused, color, size }) => {
         let iconName = "";
         switch (route.name) {

--- a/Ampara/AppHeader.tsx
+++ b/Ampara/AppHeader.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { View, Image, Text } from "react-native";
+
+interface AppHeaderProps {
+  title?: string;
+}
+
+const AppHeader: React.FC<AppHeaderProps> = ({ title }) => (
+  <View className="flex-row items-center justify-center bg-white pt-12 pb-4">
+    <Image
+      source={require("./assets/Ampara_logo.png")}
+      className="w-10 h-10"
+      resizeMode="contain"
+    />
+    {title && <Text className="ml-2 text-xl font-bold">{title}</Text>}
+  </View>
+);
+
+export default AppHeader;


### PR DESCRIPTION
## Summary
- add AppHeader component displaying logo and optional title
- wire AppHeader into navigation so Dashboard shows title "Ampara"

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d6a22fc9483229e1d424be91cb848