### PR TITLE
feat: integrate theme provider and settings

### DIFF
--- a/Ampara/App.tsx
+++ b/Ampara/App.tsx
@@ -19,6 +19,7 @@ import ElderUserProfile from "./screens/elder_profile/elder_profile";
 import { AuthContext } from "./controllers/AuthContext";
 import { designTokens } from "./design-tokens";
 import LogoTitle from "./src/components/ui/LogoTitle";
+import { ThemeProvider } from "./controllers/ThemeContext";
 
 // Navegadores
 const Tab = createBottomTabNavigator();
@@ -216,11 +217,13 @@ export default function App() {
 
   return (
     <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>
-      <View className="flex-1">
-        <NavigationContainer>
-          {isAuthenticated ? <MainTabs /> : <AuthStack />}
-        </NavigationContainer>
-      </View>
+      <ThemeProvider>
+        <View className="flex-1">
+          <NavigationContainer>
+            {isAuthenticated ? <MainTabs /> : <AuthStack />}
+          </NavigationContainer>
+        </View>
+      </ThemeProvider>
     </AuthContext.Provider>
   );
 }

--- a/Ampara/controllers/ThemeContext.tsx
+++ b/Ampara/controllers/ThemeContext.tsx
@@ -55,3 +55,4 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
 
 export const useTheme = () => useContext(ThemeContext);
 
+export default ThemeProvider;

--- a/Ampara/screens/settings/Settings.tsx
+++ b/Ampara/screens/settings/Settings.tsx
@@ -7,11 +7,11 @@ import {
   Text,
   Pressable,
   Switch,
-  useColorScheme,
   Alert,
 } from "react-native";
 import Feather from "@expo/vector-icons/Feather";
 import { designTokens } from "../../design-tokens";
+import { useTheme } from "../../controllers/ThemeContext";
 
 // Reusable row
 const Row = ({
@@ -84,13 +84,13 @@ const Card = ({
 );
 
 const Settings: React.FC = () => {
-  const scheme = useColorScheme() ?? "light";
+  const { colorScheme, setTheme } = useTheme();
+  const scheme = colorScheme;
   const tokens = designTokens[scheme];
   const navigation = useNavigation<any>();
   const { setIsAuthenticated } = useAuth();
 
   const [notifications, setNotifications] = useState(true);
-  const [darkMode, setDarkMode] = useState(scheme === "dark");
 
   const onSignOut = () => {
     Alert.alert("Sign out", "Are you sure you want to sign out?", [
@@ -158,7 +158,12 @@ const Settings: React.FC = () => {
             icon={<Feather name="moon" size={18} color={tokens.subtitle} />}
             label="Dark Mode"
             tokens={tokens}
-            right={<Switch value={darkMode} onValueChange={setDarkMode} />}
+            right={
+              <Switch
+                value={scheme === "dark"}
+                onValueChange={(value) => setTheme(value ? "dark" : "light")}
+              />
+            }
           />
           <Row
             icon={<Feather name="sliders" size={18} color={tokens.subtitle} />}


### PR DESCRIPTION
## Summary
- wrap app navigation with ThemeProvider
- expose ThemeProvider from ThemeContext
- use global theme in Settings screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find module '@react-navigation/native-stack' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a546ec4aa0832287f4def9c466aeb2