### PR TITLE
Link settings actions to OS and support pages

### DIFF
--- a/Ampara/screens/settings/Settings.tsx
+++ b/Ampara/screens/settings/Settings.tsx
@@ -9,6 +9,7 @@ import {
   Switch,
   useColorScheme,
   Alert,
+  Linking,
 } from "react-native";
 import Feather from "@expo/vector-icons/Feather";
 import { designTokens } from "../../design-tokens";
@@ -164,7 +165,7 @@ const Settings: React.FC = () => {
             icon={<Feather name="sliders" size={18} color={tokens.subtitle} />}
             label="App Settings"
             tokens={tokens}
-            onPress={() => console.log("app settings")}
+            onPress={() => Linking.openSettings()}
           />
         </Card>
 
@@ -175,30 +176,34 @@ const Settings: React.FC = () => {
         >
           Support
         </Text>
-        <Card tokens={tokens}>
-          <Row
-            icon={
-              <Feather name="help-circle" size={18} color={tokens.subtitle} />
-            }
-            label="Help Center"
-            tokens={tokens}
-            onPress={() => console.log("help center")}
-          />
-          <Row
-            icon={
-              <Feather name="file-text" size={18} color={tokens.subtitle} />
-            }
-            label="Terms & Privacy"
-            tokens={tokens}
-            onPress={() => console.log("terms")}
-          />
-          <Row
-            icon={<Feather name="shield" size={18} color={tokens.subtitle} />}
-            label="Security"
-            tokens={tokens}
-            onPress={() => console.log("security")}
-          />
-        </Card>
+          <Card tokens={tokens}>
+            <Row
+              icon={
+                <Feather name="help-circle" size={18} color={tokens.subtitle} />
+              }
+              label="Help Center"
+              tokens={tokens}
+              onPress={() =>
+                Linking.openURL("https://example.com/help-center")
+              }
+            />
+            <Row
+              icon={
+                <Feather name="file-text" size={18} color={tokens.subtitle} />
+              }
+              label="Terms & Privacy"
+              tokens={tokens}
+              onPress={() =>
+                Linking.openURL("https://example.com/terms-privacy")
+              }
+            />
+            <Row
+              icon={<Feather name="shield" size={18} color={tokens.subtitle} />}
+              label="Security"
+              tokens={tokens}
+              onPress={() => Linking.openURL("https://example.com/security")}
+            />
+          </Card>
 
         {/* Sign out */}
         <Pressable


### PR DESCRIPTION
## Summary
- open OS preferences when tapping **App Settings**
- route Help Center, Terms & Privacy, and Security to external support URLs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5481921f483228ec0c759bb1d8b11