### PR TITLE
refactor: inline palette colors

### DIFF
--- a/Ampara/global.css
+++ b/Ampara/global.css
@@ -2,27 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  :root {
-    --color-primary: 252 211 77;
-    --color-accent: 251 191 36;
-    --color-background: 255 253 247;
-    --color-text: 63 63 70;
-    --color-subtitle: 107 114 128;
-    --color-border: 212 212 216;
-    --color-badge: 254 249 195;
-    --color-highlight: 245 158 11;
-    --color-calm: 167 139 250;
-  }
-  .dark {
-    --color-primary: 252 211 77;
-    --color-accent: 251 191 36;
-    --color-background: 24 24 27;
-    --color-text: 228 228 231;
-    --color-subtitle: 156 163 175;
-    --color-border: 39 39 42;
-    --color-badge: 63 63 70;
-    --color-highlight: 217 119 6;
-    --color-calm: 124 58 237;
-  }
-}
+

--- a/Ampara/tailwind.config.js
+++ b/Ampara/tailwind.config.js
@@ -11,15 +11,15 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: "rgb(var(--color-primary) / <alpha-value>)",
-        accent: "rgb(var(--color-accent) / <alpha-value>)",
-        background: "rgb(var(--color-background) / <alpha-value>)",
-        text: "rgb(var(--color-text) / <alpha-value>)",
-        subtitle: "rgb(var(--color-subtitle) / <alpha-value>)",
-        border: "rgb(var(--color-border) / <alpha-value>)",
-        badge: "rgb(var(--color-badge) / <alpha-value>)",
-        highlight: "rgb(var(--color-highlight) / <alpha-value>)",
-        calm: "rgb(var(--color-calm) / <alpha-value>)",
+        primary: { DEFAULT: "#FCD34D", dark: "#FCD34D" },
+        accent: { DEFAULT: "#FBBF24", dark: "#F59E0B" },
+        background: { DEFAULT: "#FFFDF7", dark: "#18181B" },
+        text: { DEFAULT: "#3F3F46", dark: "#E4E4E7" },
+        subtitle: { DEFAULT: "#6B7280", dark: "#9CA3AF" },
+        border: { DEFAULT: "#D4D4D8", dark: "#27272A" },
+        badge: { DEFAULT: "#FEF9C3", dark: "#3F3F46" },
+        highlight: { DEFAULT: "#F59E0B", dark: "#D97706" },
+        calm: { DEFAULT: "#A78BFA", dark: "#7C3AED" },
       },
       spacing: {
         4: "1rem", // 16px


### PR DESCRIPTION
## Summary
- use palette hex values in Tailwind config
- drop :root color variables from global.css

## Testing
- `npx tailwindcss -i global.css --compile`

------
https://chatgpt.com/codex/tasks/task_e_68a563ef9c248322ad5addde29c02009