### PR TITLE
Refactor UI components to use palette colors with dark variants

### DIFF
--- a/Ampara/src/components/ui/Card.tsx
+++ b/Ampara/src/components/ui/Card.tsx
@@ -8,7 +8,7 @@ export interface CardProps extends ViewProps {
 const Card: React.FC<CardProps> = ({ className = "", children, ...rest }) => {
   return (
     <View
-      className={`border border-border rounded-xl bg-white ${className}`}
+      className={`border border-border dark:border-border-dark rounded-xl bg-background dark:bg-background-dark ${className}`}
       {...rest}
     >
       {children}

--- a/Ampara/src/components/ui/FormInput.tsx
+++ b/Ampara/src/components/ui/FormInput.tsx
@@ -12,15 +12,15 @@ export interface FormInputProps extends TextInputProps {
 const FormInput: React.FC<FormInputProps> = ({
   label,
   containerClassName = "mb-6",
-  labelClassName = "text-gray-700 text-base font-semibold mb-2",
-  inputClassName = "flex-1 py-3 px-4 text-lg",
+  labelClassName = "text-text dark:text-text-dark text-base font-semibold mb-2",
+  inputClassName = "flex-1 py-3 px-4 text-lg text-text dark:text-text-dark",
   rightIcon,
   ...inputProps
 }) => {
   return (
     <View className={containerClassName}>
       <Text className={labelClassName}>{label}</Text>
-      <View className="flex-row items-center border border-gray-300 rounded-lg bg-white/70">
+      <View className="flex-row items-center border border-border dark:border-border-dark rounded-lg bg-background dark:bg-background-dark">
         <TextInput className={inputClassName} {...inputProps} />
         {rightIcon}
       </View>

--- a/Ampara/src/components/ui/PrimaryButton.tsx
+++ b/Ampara/src/components/ui/PrimaryButton.tsx
@@ -15,11 +15,11 @@ const PrimaryButton: React.FC<PrimaryButtonProps> = ({
 }) => {
   return (
     <Pressable
-      className={`bg-primary rounded-xl py-4 items-center ${className}`}
+      className={`bg-primary dark:bg-primary-dark border border-primary dark:border-primary-dark rounded-xl py-4 items-center ${className}`}
       {...rest}
     >
       <Text
-        className={`text-white text-center text-lg font-semibold ${textClassName}`}
+        className={`text-text dark:text-text-dark text-center text-lg font-semibold ${textClassName}`}
       >
         {title}
       </Text>

--- a/Ampara/src/components/ui/SecondaryButton.tsx
+++ b/Ampara/src/components/ui/SecondaryButton.tsx
@@ -15,11 +15,11 @@ const SecondaryButton: React.FC<SecondaryButtonProps> = ({
 }) => {
   return (
     <Pressable
-      className={`bg-accent rounded-xl py-4 items-center ${className}`}
+      className={`bg-accent dark:bg-accent-dark border border-accent dark:border-accent-dark rounded-xl py-4 items-center ${className}`}
       {...rest}
     >
       <Text
-        className={`text-white text-center text-lg font-semibold ${textClassName}`}
+        className={`text-text dark:text-text-dark text-center text-lg font-semibold ${textClassName}`}
       >
         {title}
       </Text>


### PR DESCRIPTION
## Summary
- Adjust Card to use background and border palette classes with dark variants
- Update FormInput to use palette-based text, border, and background classes with dark theme support
- Apply palette colors with dark variants to PrimaryButton and SecondaryButton

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a563f1117c832292660fcea9167f6b