### PR TITLE
Improve authentication screen keyboard handling

### DIFF
--- a/Ampara/screens/log_in/ForgotPassword.tsx
+++ b/Ampara/screens/log_in/ForgotPassword.tsx
@@ -1,4 +1,14 @@
-import { View, TouchableOpacity, TextInput, Image, Text } from "react-native";
+import {
+  View,
+  TouchableOpacity,
+  TextInput,
+  Image,
+  Text,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+  Keyboard,
+} from "react-native";
 import React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
@@ -10,31 +20,43 @@ const ForgotPassword = () => {
   const navigation = useNavigation();
 
   return (
-    <SafeAreaView className="flex-1 bg-background justify-center items-center p-6">
-      <Card className="w-full max-w-md p-8">
-        <View className="items-center mb-8">
-          <Image
-            source={require("../../assets/Ampara_logo.png")}
-            className="w-32 h-32 mb-2"
-            resizeMode="contain"
-          />
-          <Text className="text-3xl font-bold text-text">Forgot Password</Text>
-        </View>
-        <FormInput
-          label="Email"
-          keyboardType="email-address"
-          autoCapitalize="none"
-        />
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      style={{ flex: 1 }}
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 40 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <SafeAreaView className="flex-1 bg-background justify-center items-center p-6">
+          <Card className="w-full max-w-md p-8">
+            <View className="items-center mb-8">
+              <Image
+                source={require("../../assets/Ampara_logo.png")}
+                className="w-32 h-32 mb-2"
+                resizeMode="contain"
+              />
+              <Text className="text-3xl font-bold text-text">Forgot Password</Text>
+            </View>
+            <FormInput
+              label="Email"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              returnKeyType="done"
+              onSubmitEditing={Keyboard.dismiss}
+            />
 
-        <PrimaryButton title="Send Reset Link" className="mb-4 shadow-md" />
+            <PrimaryButton title="Send Reset Link" className="mb-4 shadow-md" />
 
-        <View className="flex-row justify-center mt-2">
-          <TouchableOpacity onPress={() => navigation.navigate("LogIn")}>
-            <Text className="text-accent">Back to Log In</Text>
-          </TouchableOpacity>
-        </View>
-      </Card>
-    </SafeAreaView>
+            <View className="flex-row justify-center mt-2">
+              <TouchableOpacity onPress={() => navigation.navigate("LogIn")}>
+                <Text className="text-accent">Back to Log In</Text>
+              </TouchableOpacity>
+            </View>
+          </Card>
+        </SafeAreaView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/Ampara/screens/log_in/LogIn.tsx
+++ b/Ampara/screens/log_in/LogIn.tsx
@@ -1,5 +1,15 @@
-import { View, TouchableOpacity, TextInput, Image, Text } from "react-native";
-import React, { useState, useContext } from "react";
+import {
+  View,
+  TouchableOpacity,
+  TextInput,
+  Image,
+  Text,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+  Keyboard,
+} from "react-native";
+import React, { useState, useRef } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -26,6 +36,7 @@ const LogIn = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { setIsAuthenticated } = useAuth();
+  const passwordRef = useRef<TextInput>(null);
 
   const handleLogin = async () => {
     setError(null);
@@ -33,8 +44,16 @@ const LogIn = () => {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-background justify-center items-center p-6">
-      <Card className="w-full max-w-md bg-background rounded-xl p-8 border border-border">
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      style={{ flex: 1 }}
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 40 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <SafeAreaView className="flex-1 bg-background justify-center items-center p-6">
+          <Card className="w-full max-w-md bg-background rounded-xl p-8 border border-border">
         <View className="items-center mb-4">
           <Image
             source={require("../../assets/Ampara_logo.png")}
@@ -48,59 +67,69 @@ const LogIn = () => {
           <Body className="text-red-500 text-center mb-4">{error}</Body>
         )}
 
-        <FormInput
-          label="Email"
-          value={email}
-          onChangeText={setEmail}
-          autoCapitalize="none"
-          keyboardType="email-address"
-        />
+            <FormInput
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              returnKeyType="next"
+              onSubmitEditing={() => passwordRef.current?.focus()}
+            />
 
-        <FormInput
-          label="Password"
-          value={password}
-          onChangeText={setPassword}
-          secureTextEntry={!showPassword}
-          rightIcon={
-            <TouchableOpacity
-              onPress={() => setShowPassword((s) => !s)}
-              accessibilityRole="button"
-              accessibilityLabel={
-                showPassword ? "Hide password" : "Show password"
+            <FormInput
+              ref={passwordRef}
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry={!showPassword}
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                Keyboard.dismiss();
+                handleLogin();
+              }}
+              rightIcon={
+                <TouchableOpacity
+                  onPress={() => setShowPassword((s) => !s)}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    showPassword ? "Hide password" : "Show password"
+                  }
+                  hitSlop={8}
+                  className="p-3"
+                >
+                  <Ionicons
+                    name={showPassword ? "eye-off-outline" : "eye-outline"}
+                    size={24}
+                    color="#6B7280"
+                  />
+                </TouchableOpacity>
               }
-              hitSlop={8}
-              className="p-3"
+            />
+
+            <PrimaryButton
+              title="Log In"
+              onPress={() => setIsAuthenticated(true)}
+              className="mb-4 shadow-md"
+            />
+
+            <TouchableOpacity
+              onPress={() => navigation.navigate("ForgotPassword")}
+              className="mt-2"
             >
-              <Ionicons
-                name={showPassword ? "eye-off-outline" : "eye-outline"}
-                size={24}
-                color="#6B7280"
-              />
+              <Text className="text-center text-accent">Forgot Password?</Text>
             </TouchableOpacity>
-          }
-        />
 
-        <PrimaryButton
-          title="Log In"
-          onPress={() => setIsAuthenticated(true)}
-          className="mb-4 shadow-md"
-        />
-
-        <TouchableOpacity
-          onPress={() => navigation.navigate("ForgotPassword")}
-          className="mt-2"
-        >
-          <Text className="text-center text-accent">Forgot Password?</Text>
-        </TouchableOpacity>
-
-        <View className="flex-row justify-center mt-6">
-          <Text className="text-subtitle">Don't have an account?</Text>
-          <TouchableOpacity onPress={() => navigation.navigate("SignUp")}>
-            <Text className="text-accent font-semibold ml-1">Sign Up</Text>
-          </TouchableOpacity>
-        </View>
-      </Card>
-    </SafeAreaView>
+            <View className="flex-row justify-center mt-6">
+              <Text className="text-subtitle">Don't have an account?</Text>
+              <TouchableOpacity onPress={() => navigation.navigate("SignUp")}>
+                <Text className="text-accent font-semibold ml-1">Sign Up</Text>
+              </TouchableOpacity>
+            </View>
+          </Card>
+        </SafeAreaView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/Ampara/screens/log_in/SignUp.tsx
+++ b/Ampara/screens/log_in/SignUp.tsx
@@ -5,8 +5,12 @@ import {
   Alert,
   Image,
   Text,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+  Keyboard,
 } from "react-native";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -27,6 +31,9 @@ const SignUp = () => {
   const [elder, setElder] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const emailRef = useRef<TextInput>(null);
+  const passwordRef = useRef<TextInput>(null);
+  const elderRef = useRef<TextInput>(null);
 
   const handleSignUp = async () => {
     const passwordRegex =
@@ -64,75 +71,103 @@ const SignUp = () => {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-white justify-center items-center p-6">
-      <Card className="w-full max-w-md p-8">
-        <View className="items-center mb-8">
-          <Image
-            source={require("../../assets/Ampara_logo.png")}
-            className="w-32 h-32 mb-2"
-            resizeMode="contain"
-          />
-          <Text className="text-3xl font-bold text-text">Sign Up</Text>
-          <Text className="text-3xl font-bold text-text">Sign Up</Text>
-        </View>
-
-        {error && (
-          <Body className="text-red-500 text-center mb-4">{error}</Body>
-        )}
-
-        <FormInput label="Full Name" value={name} onChangeText={setName} />
-
-        <FormInput
-          label="Email"
-          value={email}
-          onChangeText={setEmail}
-          autoCapitalize="none"
-          keyboardType="email-address"
-        />
-
-        <FormInput
-          label="Password"
-          value={password}
-          onChangeText={setPassword}
-          secureTextEntry={!showPassword}
-          rightIcon={
-            <TouchableOpacity
-              onPress={() => setShowPassword((s) => !s)}
-              accessibilityRole="button"
-              accessibilityLabel={
-                showPassword ? "Hide password" : "Show password"
-              }
-              hitSlop={8}
-              className="p-3"
-            >
-              <Ionicons
-                name={showPassword ? "eye-off-outline" : "eye-outline"}
-                size={24}
-                color="#6B7280"
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      style={{ flex: 1 }}
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 40 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <SafeAreaView className="flex-1 bg-white justify-center items-center p-6">
+          <Card className="w-full max-w-md p-8">
+            <View className="items-center mb-8">
+              <Image
+                source={require("../../assets/Ampara_logo.png")}
+                className="w-32 h-32 mb-2"
+                resizeMode="contain"
               />
-            </TouchableOpacity>
-          }
-        />
-        <FormInput
-          label="Connect to Elder (Name or ID)"
-          value={elder}
-          onChangeText={setElder}
-        />
+              <Text className="text-3xl font-bold text-text">Sign Up</Text>
+              <Text className="text-3xl font-bold text-text">Sign Up</Text>
+            </View>
 
-        <PrimaryButton
-          title="Sign Up"
-          onPress={handleSignUp}
-          className="mb-4 shadow-md"
-        />
+            {error && (
+              <Body className="text-red-500 text-center mb-4">{error}</Body>
+            )}
 
-        <View className="flex-row justify-center mt-6">
-          <Text className="text-subtitle">Already have an account?</Text>
-          <TouchableOpacity onPress={() => navigation.navigate("LogIn")}>
-            <Text className="text-accent font-semibold ml-1">Log In</Text>
-          </TouchableOpacity>
-        </View>
-      </Card>
-    </SafeAreaView>
+            <FormInput
+              label="Full Name"
+              value={name}
+              onChangeText={setName}
+              returnKeyType="next"
+              onSubmitEditing={() => emailRef.current?.focus()}
+            />
+
+            <FormInput
+              ref={emailRef}
+              label="Email"
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              returnKeyType="next"
+              onSubmitEditing={() => passwordRef.current?.focus()}
+            />
+
+            <FormInput
+              ref={passwordRef}
+              label="Password"
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry={!showPassword}
+              returnKeyType="next"
+              onSubmitEditing={() => elderRef.current?.focus()}
+              rightIcon={
+                <TouchableOpacity
+                  onPress={() => setShowPassword((s) => !s)}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    showPassword ? "Hide password" : "Show password"
+                  }
+                  hitSlop={8}
+                  className="p-3"
+                >
+                  <Ionicons
+                    name={showPassword ? "eye-off-outline" : "eye-outline"}
+                    size={24}
+                    color="#6B7280"
+                  />
+                </TouchableOpacity>
+              }
+            />
+            <FormInput
+              ref={elderRef}
+              label="Connect to Elder (Name or ID)"
+              value={elder}
+              onChangeText={setElder}
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                Keyboard.dismiss();
+                handleSignUp();
+              }}
+            />
+
+            <PrimaryButton
+              title="Sign Up"
+              onPress={handleSignUp}
+              className="mb-4 shadow-md"
+            />
+
+            <View className="flex-row justify-center mt-6">
+              <Text className="text-subtitle">Already have an account?</Text>
+              <TouchableOpacity onPress={() => navigation.navigate("LogIn")}>
+                <Text className="text-accent font-semibold ml-1">Log In</Text>
+              </TouchableOpacity>
+            </View>
+          </Card>
+        </SafeAreaView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/Ampara/src/components/ui/FormInput.tsx
+++ b/Ampara/src/components/ui/FormInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { View, Text, TextInput, TextInputProps } from "react-native";
 
 export interface FormInputProps extends TextInputProps {
@@ -9,23 +9,28 @@ export interface FormInputProps extends TextInputProps {
   rightIcon?: React.ReactNode;
 }
 
-const FormInput: React.FC<FormInputProps> = ({
-  label,
-  containerClassName = "mb-6",
-  labelClassName = "text-gray-700 text-base font-semibold mb-2",
-  inputClassName = "flex-1 py-3 px-4 text-lg",
-  rightIcon,
-  ...inputProps
-}) => {
-  return (
-    <View className={containerClassName}>
-      <Text className={labelClassName}>{label}</Text>
-      <View className="flex-row items-center border border-gray-300 rounded-lg bg-white/70">
-        <TextInput className={inputClassName} {...inputProps} />
-        {rightIcon}
+const FormInput = forwardRef<TextInput, FormInputProps>(
+  (
+    {
+      label,
+      containerClassName = "mb-6",
+      labelClassName = "text-gray-700 text-base font-semibold mb-2",
+      inputClassName = "flex-1 py-3 px-4 text-lg",
+      rightIcon,
+      ...inputProps
+    },
+    ref
+  ) => {
+    return (
+      <View className={containerClassName}>
+        <Text className={labelClassName}>{label}</Text>
+        <View className="flex-row items-center border border-gray-300 rounded-lg bg-white/70">
+          <TextInput ref={ref} className={inputClassName} {...inputProps} />
+          {rightIcon}
+        </View>
       </View>
-    </View>
-  );
-};
+    );
+  }
+);
 
 export default FormInput;


### PR DESCRIPTION
## Summary
- wrap log in, sign up, and forgot password screens with `KeyboardAvoidingView` and `ScrollView`
- add `returnKeyType` and `onSubmitEditing` handlers to form inputs to dismiss keyboard or move focus
- allow `FormInput` to accept refs for focusing the next field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: cannot find module types / navigation types)*

------
https://chatgpt.com/codex/tasks/task_e_68a563f4089c8322bff6187e9c2f0366