### PR TITLE
Handle network errors on login screen

### DIFF
--- a/Ampara/screens/log_in/LogIn.tsx
+++ b/Ampara/screens/log_in/LogIn.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   Platform,
   Keyboard,
+  Alert,
 } from "react-native";
 import React, { useState, useRef } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -58,14 +59,19 @@ const LogIn = () => {
         }
       } catch (err) {
         Alert.alert(
-          "Network Error",
-          "Could not fetch user information. Please try again later."
+          "Server Unavailable",
+          "Could not fetch user information. Please check the server URL or try again later."
         );
       }
     } catch (e) {
+      setError("Server unavailable. Please check the server URL or try again.");
       Alert.alert(
-        "Network Error",
-        "Unable to connect. Please check your internet connection."
+        "Server Unavailable",
+        "Unable to reach the server. Please check the server URL or your connection.",
+        [
+          { text: "Retry", onPress: handleLogin },
+          { text: "OK" },
+        ]
       );
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- differentiate server responses from network failures in login
- show "Server Unavailable" with retry when fetch rejects

## Testing
- ⚠️ `npm test` (missing script: `test`)


------
https://chatgpt.com/codex/tasks/task_e_68a6767842788322b719f397b341feba