### PR TITLE
Handle nullable Mongoose results and configure API base URL

### DIFF
--- a/Ampara/services/api.ts
+++ b/Ampara/services/api.ts
@@ -1,8 +1,15 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
 
-const BASE_URL = `http://${process.env.SERVER_URL || 'localhost:3000'}`;
+const SERVER_URL =
+  process.env.SERVER_URL ||
+  (Platform.OS === 'android' ? '10.0.2.2:3000' : 'localhost:3000');
+const BASE_URL = `http://${SERVER_URL}`;
 
-export const apiFetch = async (endpoint: string, options: RequestInit = {}) => {
+export const apiFetch = async (
+  endpoint: string,
+  options: RequestInit = {},
+) => {
   const token = await AsyncStorage.getItem('access_token');
   const headers = {
     'Content-Type': 'application/json',
@@ -10,7 +17,14 @@ export const apiFetch = async (endpoint: string, options: RequestInit = {}) => {
     ...(options.headers || {}),
   } as Record<string, string>;
 
-  return fetch(`${BASE_URL}${endpoint}`, { ...options, headers });
+  try {
+    return await fetch(`${BASE_URL}${endpoint}`, { ...options, headers });
+  } catch (error) {
+    console.error(`Failed to fetch from ${BASE_URL}`, error);
+    throw new Error(
+      `Could not connect to backend at ${BASE_URL}. Is the server running?`,
+    );
+  }
 };
 
 export default apiFetch;

--- a/classProject/server/src/modules/advice-requests/advice-requests.controller.ts
+++ b/classProject/server/src/modules/advice-requests/advice-requests.controller.ts
@@ -22,12 +22,15 @@ export class AdviceRequestsController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<AdviceRequest> {
+  async findOne(@Param('id') id: string): Promise<AdviceRequest | null> {
     return this.adviceRequestsService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateAdviceRequestDto: Partial<AdviceRequest>): Promise<AdviceRequest> {
+  async update(
+    @Param('id') id: string,
+    @Body() updateAdviceRequestDto: Partial<AdviceRequest>,
+  ): Promise<AdviceRequest | null> {
     return this.adviceRequestsService.update(id, updateAdviceRequestDto);
   }
 

--- a/classProject/server/src/modules/advice-requests/advice-requests.service.ts
+++ b/classProject/server/src/modules/advice-requests/advice-requests.service.ts
@@ -22,12 +22,21 @@ export class AdviceRequestsService {
     return this.adviceRequestModel.find({ elderId }).populate(['elderId', 'visitorId']).sort({ askedAt: -1 }).exec();
   }
 
-  async findOne(id: string): Promise<AdviceRequest> {
-    return this.adviceRequestModel.findById(id).populate(['elderId', 'visitorId']).exec();
+  async findOne(id: string): Promise<AdviceRequest | null> {
+    return this.adviceRequestModel
+      .findById(id)
+      .populate(['elderId', 'visitorId'])
+      .exec();
   }
 
-  async update(id: string, updateAdviceRequestDto: Partial<AdviceRequest>): Promise<AdviceRequest> {
-    return this.adviceRequestModel.findByIdAndUpdate(id, updateAdviceRequestDto, { new: true }).populate(['elderId', 'visitorId']).exec();
+  async update(
+    id: string,
+    updateAdviceRequestDto: Partial<AdviceRequest>,
+  ): Promise<AdviceRequest | null> {
+    return this.adviceRequestModel
+      .findByIdAndUpdate(id, updateAdviceRequestDto, { new: true })
+      .populate(['elderId', 'visitorId'])
+      .exec();
   }
 
   async remove(id: string): Promise<void> {

--- a/classProject/server/src/modules/ai-instructions/ai-instructions.controller.ts
+++ b/classProject/server/src/modules/ai-instructions/ai-instructions.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Put,
   Delete,
+  BadRequestException,
 } from '@nestjs/common';
 import { AiInstructionsService } from './ai-instructions.service';
 import { AiInstruction } from './ai-instructions.schema';
@@ -19,9 +20,16 @@ export class AiInstructionsController {
     @Body() createAiInstructionDto: Partial<AiInstruction>,
   ): Promise<AiInstruction> {
     const { elderId, createdBy, message, aiResponse } = createAiInstructionDto;
+
+    if (!elderId || !createdBy || !message) {
+      throw new BadRequestException(
+        'elderId, createdBy and message are required',
+      );
+    }
+
     return this.aiInstructionsService.createInstruction(
-      elderId,
-      createdBy,
+      elderId as any,
+      createdBy as any,
       message,
       aiResponse,
     );
@@ -40,7 +48,7 @@ export class AiInstructionsController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<AiInstruction> {
+  async findOne(@Param('id') id: string): Promise<AiInstruction | null> {
     return this.aiInstructionsService.findOne(id);
   }
 
@@ -58,7 +66,7 @@ export class AiInstructionsController {
   async update(
     @Param('id') id: string,
     @Body() updateAiInstructionDto: Partial<AiInstruction>,
-  ): Promise<AiInstruction> {
+  ): Promise<AiInstruction | null> {
     return this.aiInstructionsService.update(id, updateAiInstructionDto);
   }
 

--- a/classProject/server/src/modules/ai-instructions/ai-instructions.service.ts
+++ b/classProject/server/src/modules/ai-instructions/ai-instructions.service.ts
@@ -60,7 +60,7 @@ export class AiInstructionsService {
       .exec();
   }
 
-  async findOne(id: string): Promise<AiInstruction> {
+  async findOne(id: string): Promise<AiInstruction | null> {
     return this.aiInstructionModel
       .findById(id)
       .populate(['elderId', 'createdBy', 'callId'])
@@ -70,7 +70,7 @@ export class AiInstructionsService {
   async update(
     id: string,
     updateAiInstructionDto: Partial<AiInstruction>,
-  ): Promise<AiInstruction> {
+  ): Promise<AiInstruction | null> {
     return this.aiInstructionModel
       .findByIdAndUpdate(id, updateAiInstructionDto, { new: true })
       .populate(['elderId', 'createdBy', 'callId'])

--- a/classProject/server/src/modules/calls/calls.controller.ts
+++ b/classProject/server/src/modules/calls/calls.controller.ts
@@ -22,12 +22,15 @@ export class CallsController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Call> {
+  async findOne(@Param('id') id: string): Promise<Call | null> {
     return this.callsService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateCallDto: Partial<Call>): Promise<Call> {
+  async update(
+    @Param('id') id: string,
+    @Body() updateCallDto: Partial<Call>,
+  ): Promise<Call | null> {
     return this.callsService.update(id, updateCallDto);
   }
 

--- a/classProject/server/src/modules/calls/calls.service.ts
+++ b/classProject/server/src/modules/calls/calls.service.ts
@@ -22,12 +22,21 @@ export class CallsService {
     return this.callModel.find({ elderId }).populate(['elderId', 'instructions']).sort({ calledAt: -1 }).exec();
   }
 
-  async findOne(id: string): Promise<Call> {
-    return this.callModel.findById(id).populate(['elderId', 'instructions']).exec();
+  async findOne(id: string): Promise<Call | null> {
+    return this.callModel
+      .findById(id)
+      .populate(['elderId', 'instructions'])
+      .exec();
   }
 
-  async update(id: string, updateCallDto: Partial<Call>): Promise<Call> {
-    return this.callModel.findByIdAndUpdate(id, updateCallDto, { new: true }).populate(['elderId', 'instructions']).exec();
+  async update(
+    id: string,
+    updateCallDto: Partial<Call>,
+  ): Promise<Call | null> {
+    return this.callModel
+      .findByIdAndUpdate(id, updateCallDto, { new: true })
+      .populate(['elderId', 'instructions'])
+      .exec();
   }
 
   async remove(id: string): Promise<void> {

--- a/classProject/server/src/modules/elder-users/elder-users.controller.ts
+++ b/classProject/server/src/modules/elder-users/elder-users.controller.ts
@@ -17,12 +17,15 @@ export class ElderUsersController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<ElderUser> {
+  async findOne(@Param('id') id: string): Promise<ElderUser | null> {
     return this.elderUsersService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateElderUserDto: Partial<ElderUser>): Promise<ElderUser> {
+  async update(
+    @Param('id') id: string,
+    @Body() updateElderUserDto: Partial<ElderUser>,
+  ): Promise<ElderUser | null> {
     return this.elderUsersService.update(id, updateElderUserDto);
   }
 

--- a/classProject/server/src/modules/elder-users/elder-users.service.ts
+++ b/classProject/server/src/modules/elder-users/elder-users.service.ts
@@ -18,12 +18,21 @@ export class ElderUsersService {
     return this.elderUserModel.find().populate('caregivers').exec();
   }
 
-  async findOne(id: string): Promise<ElderUser> {
-    return this.elderUserModel.findById(id).populate('caregivers').exec();
+  async findOne(id: string): Promise<ElderUser | null> {
+    return this.elderUserModel
+      .findById(id)
+      .populate('caregivers')
+      .exec();
   }
 
-  async update(id: string, updateElderUserDto: Partial<ElderUser>): Promise<ElderUser> {
-    return this.elderUserModel.findByIdAndUpdate(id, updateElderUserDto, { new: true }).populate('caregivers').exec();
+  async update(
+    id: string,
+    updateElderUserDto: Partial<ElderUser>,
+  ): Promise<ElderUser | null> {
+    return this.elderUserModel
+      .findByIdAndUpdate(id, updateElderUserDto, { new: true })
+      .populate('caregivers')
+      .exec();
   }
 
   async remove(id: string): Promise<void> {

--- a/classProject/server/src/modules/moods/moods.controller.ts
+++ b/classProject/server/src/modules/moods/moods.controller.ts
@@ -22,12 +22,15 @@ export class MoodsController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Mood> {
+  async findOne(@Param('id') id: string): Promise<Mood | null> {
     return this.moodsService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateMoodDto: Partial<Mood>): Promise<Mood> {
+  async update(
+    @Param('id') id: string,
+    @Body() updateMoodDto: Partial<Mood>,
+  ): Promise<Mood | null> {
     return this.moodsService.update(id, updateMoodDto);
   }
 

--- a/classProject/server/src/modules/moods/moods.service.ts
+++ b/classProject/server/src/modules/moods/moods.service.ts
@@ -22,12 +22,18 @@ export class MoodsService {
     return this.moodModel.find({ elderId }).populate('elderId').sort({ timestamp: -1 }).exec();
   }
 
-  async findOne(id: string): Promise<Mood> {
+  async findOne(id: string): Promise<Mood | null> {
     return this.moodModel.findById(id).populate('elderId').exec();
   }
 
-  async update(id: string, updateMoodDto: Partial<Mood>): Promise<Mood> {
-    return this.moodModel.findByIdAndUpdate(id, updateMoodDto, { new: true }).populate('elderId').exec();
+  async update(
+    id: string,
+    updateMoodDto: Partial<Mood>,
+  ): Promise<Mood | null> {
+    return this.moodModel
+      .findByIdAndUpdate(id, updateMoodDto, { new: true })
+      .populate('elderId')
+      .exec();
   }
 
   async remove(id: string): Promise<void> {

--- a/classProject/server/src/modules/users/users.controller.ts
+++ b/classProject/server/src/modules/users/users.controller.ts
@@ -17,12 +17,15 @@ export class UsersController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<User> {
+  async findOne(@Param('id') id: string): Promise<User | null> {
     return this.usersService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateUserDto: Partial<User>): Promise<User> {
+  async update(
+    @Param('id') id: string,
+    @Body() updateUserDto: Partial<User>,
+  ): Promise<User | null> {
     return this.usersService.update(id, updateUserDto);
   }
 

--- a/classProject/server/src/modules/users/users.service.ts
+++ b/classProject/server/src/modules/users/users.service.ts
@@ -18,12 +18,18 @@ export class UsersService {
     return this.userModel.find().populate('linkedElders').exec();
   }
 
-  async findOne(id: string): Promise<User> {
+  async findOne(id: string): Promise<User | null> {
     return this.userModel.findById(id).populate('linkedElders').exec();
   }
 
-  async update(id: string, updateUserDto: Partial<User>): Promise<User> {
-    return this.userModel.findByIdAndUpdate(id, updateUserDto, { new: true }).populate('linkedElders').exec();
+  async update(
+    id: string,
+    updateUserDto: Partial<User>,
+  ): Promise<User | null> {
+    return this.userModel
+      .findByIdAndUpdate(id, updateUserDto, { new: true })
+      .populate('linkedElders')
+      .exec();
   }
 
   async remove(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Allow Mongoose service methods and controllers to return `null` for missing documents
- Validate AI instruction creation input and require mandatory fields
- Configure API client `SERVER_URL` with platform-aware default and clearer fetch errors

## Testing
- `npm run build`
- `npm test` *(fails: Nest can't resolve dependencies of UsersService/UsersController)*
- `npm test` in `Ampara` *(fails: Missing script "test")*
- `npm run start` *(fails: Unable to connect to the database, `MONGO_URI` undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a676773f0083228f605c3cba0abdbb