### PR TITLE
Use Expo env var for backend URL and document physical-device testing

### DIFF
--- a/Ampara/README.md
+++ b/Ampara/README.md
@@ -1,0 +1,11 @@
+# Ampara
+
+## Physical Device Testing
+
+Set the Expo static environment variable `EXPO_PUBLIC_SERVER_URL` to your computer's LAN IP and backend port so the app can reach the development server when running on a physical device:
+
+```sh
+EXPO_PUBLIC_SERVER_URL=192.168.1.2:3000 expo start
+```
+
+Replace `192.168.1.2` with your machine's LAN address.

--- a/Ampara/services/api.ts
+++ b/Ampara/services/api.ts
@@ -1,9 +1,18 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
+import Constants from 'expo-constants';
 
-const SERVER_URL =
-  process.env.SERVER_URL ||
-  (Platform.OS === 'android' ? '10.0.2.2:3000' : 'localhost:3000');
+const getDefaultServerUrl = () => {
+  const hostUri = Constants.expoConfig?.hostUri;
+  if (hostUri) {
+    const [lanIp] = hostUri.split(':');
+    return `${lanIp}:3000`;
+  }
+  const fallbackHost = Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
+  return `${fallbackHost}:3000`;
+};
+
+const SERVER_URL = process.env.EXPO_PUBLIC_SERVER_URL || getDefaultServerUrl();
 const BASE_URL = `http://${SERVER_URL}`;
 
 export const apiFetch = async (


### PR DESCRIPTION
## Summary
- derive server URL from `EXPO_PUBLIC_SERVER_URL` or Expo `hostUri`
- add README note on setting `EXPO_PUBLIC_SERVER_URL` when testing on a device

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6864f61ec832287fe3ee2949f397a