### PR TITLE
Refactor API usage for emotional check-in and elder creation

### DIFF
--- a/Ampara/screens/auth/CreateElderUser.tsx
+++ b/Ampara/screens/auth/CreateElderUser.tsx
@@ -15,7 +15,7 @@ import Card from "../../src/components/ui/Card";
 import FormInput from "../../src/components/ui/FormInput";
 import PrimaryButton from "../../src/components/ui/PrimaryButton";
 import { useNavigation } from "@react-navigation/native";
-import apiFetch from "../../services/api";
+import { apiService } from "../../services/api";
 
 const toList = (s: string) =>
   s
@@ -61,21 +61,32 @@ export default function CreateElderUser() {
 
     setLoading(true);
     try {
-      const res = await apiFetch("/elder-users", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Could not create elder user.");
-        return;
+      const response: any = await apiService.createElderUser(payload);
+
+      if (
+        response &&
+        typeof response === "object" &&
+        "success" in response &&
+        response.success === false
+      ) {
+        throw new Error(response.message || "Could not create elder user.");
       }
-      await res.json();
-      Alert.alert("Created!", "Elder profile created.", [
+
+      const successMessage =
+        (response &&
+          typeof response === "object" &&
+          "message" in response &&
+          typeof response.message === "string" &&
+          response.message) ||
+        (typeof response === "string" && response) ||
+        "Elder profile created.";
+
+      Alert.alert("Created!", successMessage, [
         { text: "OK", onPress: () => nav.navigate("LogIn") },
       ]);
     } catch (e: any) {
-      Alert.alert("Network error", e?.message ?? "Please try again.");
+      console.error("Failed to create elder user", e);
+      Alert.alert("Error", e?.message ?? "Could not create elder user.");
     } finally {
       setLoading(false);
     }

--- a/Ampara/screens/dashboard/EmotionalCheckIn.tsx
+++ b/Ampara/screens/dashboard/EmotionalCheckIn.tsx
@@ -14,7 +14,7 @@ import {
 import { useRoute, RouteProp } from "@react-navigation/native";
 import FormInput from "../../src/components/ui/FormInput";
 import PrimaryButton from "../../src/components/ui/PrimaryButton";
-import apiFetch from "../../services/api";
+import { apiService } from "../../services/api";
 
 type MoodItem = {
   _id?: string;
@@ -91,13 +91,40 @@ const EmotionalCheckIns: React.FC = () => {
     if (!elderId) return;
     setLoading(true);
     try {
-      const res = await apiFetch(`/moods/elder/${elderId}`);
-      if (!res.ok) {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Could not load moods.");
-        return;
+      const response: any = await apiService.get(`/moods/elder/${elderId}`);
+
+      if (
+        response &&
+        typeof response === "object" &&
+        "success" in response &&
+        response.success === false
+      ) {
+        throw new Error(response.message || "Could not load moods.");
       }
-      const list: MoodItem[] = await res.json();
+
+      let list: MoodItem[] | undefined;
+      if (Array.isArray(response)) {
+        list = response;
+      } else if (
+        response &&
+        typeof response === "object" &&
+        "data" in response &&
+        Array.isArray(response.data)
+      ) {
+        list = response.data as MoodItem[];
+      } else if (
+        response &&
+        typeof response === "object" &&
+        "moods" in response &&
+        Array.isArray((response as any).moods)
+      ) {
+        list = (response as any).moods as MoodItem[];
+      }
+
+      if (!list) {
+        throw new Error("Unexpected response format when loading moods.");
+      }
+
       // Orden por fecha desc
       list.sort(
         (a, b) =>
@@ -105,7 +132,11 @@ const EmotionalCheckIns: React.FC = () => {
       );
       setMoods(list);
     } catch (e: any) {
-      Alert.alert("Network error", e?.message ?? "Please try again.");
+      console.error("Failed to load moods", e);
+      Alert.alert(
+        "Error",
+        e?.message ?? "Could not load moods. Please try again later."
+      );
     } finally {
       setLoading(false);
     }
@@ -168,16 +199,32 @@ const EmotionalCheckIns: React.FC = () => {
     };
 
     try {
-      const res = await apiFetch("/moods", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Could not save mood.");
-        return;
+      const response: any = await apiService.post<MoodItem | { data?: MoodItem }>(
+        "/moods",
+        payload
+      );
+
+      if (
+        response &&
+        typeof response === "object" &&
+        "success" in response &&
+        response.success === false
+      ) {
+        throw new Error(response.message || "Could not save mood.");
       }
-      const created: MoodItem = await res.json();
+
+      let created: MoodItem | undefined;
+      if (response && typeof response === "object") {
+        if ("data" in response && response.data) {
+          created = response.data as MoodItem;
+        } else if ("mood" in response || "_id" in response) {
+          created = response as MoodItem;
+        }
+      }
+
+      if (!created) {
+        throw new Error("Unexpected response format when saving mood.");
+      }
       // adjuntar nota solo localmente (para mostrarla)
       created.note = newNote || undefined;
 
@@ -189,7 +236,8 @@ const EmotionalCheckIns: React.FC = () => {
       );
       closeModal();
     } catch (e: any) {
-      Alert.alert("Network error", e?.message ?? "Please try again.");
+      console.error("Failed to save mood", e);
+      Alert.alert("Error", e?.message ?? "Could not save mood.");
     }
   };
 


### PR DESCRIPTION
## Summary
- switch emotional check-in screen to use the shared apiService and parse helper payloads when loading and saving moods
- update elder creation auth screen to call apiService.createElderUser and derive success messaging from the resolved payload
- harden both screens' error handling by validating parsed responses instead of relying on fetch response helpers

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7d195c08322a0fc5e89ab67187a